### PR TITLE
Extend cookie expiration for active visits

### DIFF
--- a/ahoy.js
+++ b/ahoy.js
@@ -151,8 +151,8 @@
 
     if (!visitId) {
       visitId = generateId();
-      setCookie("ahoy_visit", visitId, visitTtl);
     }
+    setCookie("ahoy_visit", visitId, visitTtl);
 
     // make sure cookies are enabled
     if (getCookie("ahoy_visit")) {


### PR DESCRIPTION
Expiration of `ahoy_visit` cookie should be extended if the visitor is
actively visiting other pages within the visitTtl.
