### PR TITLE
Extend cookie expiration for active visits

### DIFF
--- a/ahoy.js
+++ b/ahoy.js
@@ -141,7 +141,7 @@
   track = getCookie("ahoy_track");
 
   if (visitId && visitorId && !track) {
-    // TODO keep visit alive?
+    setCookie("ahoy_visit", visitId, visitTtl);
     log("Active visit");
     setReady();
   } else {


### PR DESCRIPTION
Expiration of `ahoy_visit` cookie should be extended if the visitor is
actively visiting other pages within the visitTtl.
